### PR TITLE
add stop action

### DIFF
--- a/cmd/macadam/stop.go
+++ b/cmd/macadam/stop.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"github.com/cfergeau/macadam/cmd/macadam/registry"
+	macadam "github.com/cfergeau/macadam/pkg/machinedriver"
+	"github.com/spf13/cobra"
+)
+
+var (
+	stopCmd = &cobra.Command{
+		Use:     "stop",
+		Short:   "Stop an existing machine",
+		Long:    "Stop a managed virtual machine ",
+		RunE:    stop,
+		Args:    cobra.MaximumNArgs(0),
+		Example: `macadam stop`,
+	}
+)
+
+func init() {
+	registry.Commands = append(registry.Commands, registry.CliCommand{
+		Command: stopCmd,
+	})
+}
+
+func stop(cmd *cobra.Command, args []string) error {
+	driver, err := macadam.GetDriverByMachineName(defaultMachineName)
+	if err != nil {
+		return nil
+	}
+
+	return driver.Stop()
+}


### PR DESCRIPTION
it adds a basic stop action which do not accept any args. As only the default macadam machine can be init and started, the stop only works with it.

It is built over the cmdline branch