### PR TITLE
add rm action

### DIFF
--- a/cmd/macadam/rm.go
+++ b/cmd/macadam/rm.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"github.com/cfergeau/macadam/cmd/macadam/registry"
+	macadam "github.com/cfergeau/macadam/pkg/machinedriver"
+	"github.com/containers/podman/v5/pkg/machine"
+	"github.com/spf13/cobra"
+)
+
+var (
+	rmCmd = &cobra.Command{
+		Use:     "rm [options]",
+		Short:   "Remove an existing machine",
+		Long:    "Remove a managed virtual machine ",
+		RunE:    rm,
+		Args:    cobra.MaximumNArgs(0),
+		Example: `macadam rm`,
+	}
+)
+
+var (
+	destroyOptions machine.RemoveOptions
+)
+
+func init() {
+	registry.Commands = append(registry.Commands, registry.CliCommand{
+		Command: rmCmd,
+	})
+}
+
+func rm(_ *cobra.Command, args []string) error {
+	driver, err := macadam.GetDriverByMachineName(defaultMachineName)
+	if err != nil {
+		return nil
+	}
+
+	return driver.Remove()
+}


### PR DESCRIPTION
it adds a basic rm action which do not accept any args. As only the default macadam machine can be init, the rm only works with it.

it is built over the cmdline branch