### PR TITLE
add force flag to remove action

### DIFF
--- a/cmd/macadam/rm.go
+++ b/cmd/macadam/rm.go
@@ -26,6 +26,10 @@ func init() {
 	registry.Commands = append(registry.Commands, registry.CliCommand{
 		Command: rmCmd,
 	})
+
+	flags := rmCmd.Flags()
+	formatFlagName := "force"
+	flags.BoolVarP(&destroyOptions.Force, formatFlagName, "f", false, "Stop and do not prompt before rming")
 }
 
 func rm(_ *cobra.Command, args []string) error {
@@ -34,5 +38,5 @@ func rm(_ *cobra.Command, args []string) error {
 		return nil
 	}
 
-	return driver.Remove()
+	return driver.RemoveWithOptions(destroyOptions)
 }

--- a/pkg/machinedriver/driver.go
+++ b/pkg/machinedriver/driver.go
@@ -501,6 +501,10 @@ func (d *Driver) Kill() error {
 
 // Remove a host
 func (d *Driver) Remove() error {
+	return d.RemoveWithOptions(machine.RemoveOptions{})
+}
+
+func (d *Driver) RemoveWithOptions(opts machine.RemoveOptions) error {
 	machineName := d.vmConfig.Name
 	fmt.Printf("Removing machine %q\n", machineName)
 	dirs, err := env.GetMachineDirs(d.vmProvider.VMType())
@@ -511,7 +515,7 @@ func (d *Driver) Remove() error {
 		return err
 	}
 
-	if err := shim.Remove(d.vmConfig, d.vmProvider, dirs, machine.RemoveOptions{}); err != nil {
+	if err := shim.Remove(d.vmConfig, d.vmProvider, dirs, opts); err != nil {
 		return err
 	}
 	//newMachineEvent(events.Remove, events.Event{Name: vmName})


### PR DESCRIPTION
when removing a machine the user is asked to confirm the deletion. However, in some cases, like an extension in podman desktop, the user has already been asked for a confirmation and we just need a way to delete the machine without prompts. This patch adds the force flag to achieve this.